### PR TITLE
Feature/sc 248/firmware image build break out package installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,8 @@ RUN chroot /workdir/rootfs/ ln -sf /bin/busybox /bin/usleep
 # create users and set password
 RUN chroot /workdir/rootfs/ useradd -m -G audio -s /bin/bash user
 RUN chroot /workdir/rootfs/ usermod -a -G video user
-RUN chroot /workdir/rootfs/ echo "user:user" | chpasswd
-RUN chroot /workdir/rootfs/ echo "root:root" | chpasswd
+RUN chroot /workdir/rootfs/ bash -c 'echo "user:user" | chpasswd'
+RUN chroot /workdir/rootfs/ bash -c 'echo "root:root" | chpasswd'
 
 RUN --security=insecure MACHINE=imx6ul-var-dart ./var_make_debian.sh -c rootfs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,63 @@ RUN MACHINE=imx6ul-var-dart ./var_make_debian.sh -c kernel
 RUN MACHINE=imx6ul-var-dart ./var_make_debian.sh -c modules
 RUN MACHINE=imx6ul-var-dart ./var_make_debian.sh -c kernelheaders
 
-# This step takes a long time. We should avoid making changes to things above this line 
+# This step takes a long time. We should avoid making changes to things above this line
+RUN --security=insecure MACHINE=imx6ul-var-dart ./var_make_debian.sh -c prep-rootfs
+# apply debconfig options
+RUN chroot /workdir/rootfs/ debconf-set-selections /debconf.set
+RUN chroot /workdir/rootfs/ rm -f /debconf.set
+RUN chroot /workdir/rootfs/ apt-get update || apt-get upgrade
+COPY variscite/protected_install /workdir/rootfs/usr/local/bin/protected_install
+RUN chroot /workdir/rootfs/ protected_install local-apt-repository
+RUN chroot /workdir/rootfs/ apt-get update || apt-get upgrade
+RUN chroot /workdir/rootfs/ protected_install udisks2
+RUN chroot /workdir/rootfs/ protected_install locales
+RUN chroot /workdir/rootfs/ protected_install ntp
+RUN chroot /workdir/rootfs/ protected_install openssh-server
+RUN chroot /workdir/rootfs/ protected_install nfs-common
+RUN chroot /workdir/rootfs/ protected_install dosfstools
+RUN chroot /workdir/rootfs/ sed -i -e 's/#PermitRootLogin.*/PermitRootLogin\tyes/g' /etc/ssh/sshd_config
+RUN chroot /workdir/rootfs/ protected_install net-tools
+RUN chroot /workdir/rootfs/ protected_install network-manager
+RUN chroot /workdir/rootfs/ protected_install psmisc
+RUN chroot /workdir/rootfs/ protected_install alsa-utils
+RUN chroot /workdir/rootfs/ protected_install i2c-tools
+RUN chroot /workdir/rootfs/ protected_install usbutils
+RUN chroot /workdir/rootfs/ protected_install gpiod
+RUN chroot /workdir/rootfs/ protected_install libgpiod2
+RUN chroot /workdir/rootfs/ protected_install python3-libgpiod
+RUN chroot /workdir/rootfs/ protected_install iperf3
+RUN chroot /workdir/rootfs/ protected_install rng-tools
+RUN chroot /workdir/rootfs/ protected_install mtd-utils
+RUN chroot /workdir/rootfs/ protected_install bluetooth
+RUN chroot /workdir/rootfs/ protected_install bluez-obexd
+RUN chroot /workdir/rootfs/ protected_install bluez-tools
+RUN chroot /workdir/rootfs/ protected_install pulseaudio
+RUN chroot /workdir/rootfs/ protected_install pulseaudio-module-bluetooth
+RUN chroot /workdir/rootfs/ protected_install hostapd
+RUN chroot /workdir/rootfs/ protected_install udhcpd
+RUN chroot /workdir/rootfs/ systemctl disable hostapd.service
+RUN chroot /workdir/rootfs/ protected_install can-utils
+RUN chroot /workdir/rootfs/ protected_install pmount
+RUN chroot /workdir/rootfs/ protected_install pm-utils
+RUN chroot /workdir/rootfs/ protected_install debhelper
+RUN chroot /workdir/rootfs/ protected_install dh-python
+RUN chroot /workdir/rootfs/ protected_install apt-src
+RUN chroot /workdir/rootfs/ apt-get -y autoremove
+
+RUN --security=insecure MACHINE=imx6ul-var-dart ./var_make_debian.sh -c rootfs
+
+#update iptables alternatives to legacy
+RUN chroot /workdir/rootfs/ update-alternatives --set iptables /usr/sbin/iptables-legacy
+RUN chroot /workdir/rootfs/ update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+RUN chroot /workdir/rootfs/ ln -sf /bin/busybox /bin/usleep
+# create users and set password
+RUN chroot /workdir/rootfs/ useradd -m -G audio -s /bin/bash user
+RUN chroot /workdir/rootfs/ usermod -a -G video user
+RUN chroot /workdir/rootfs/ echo "user:user" | chpasswd
+RUN chroot /workdir/rootfs/ echo "root:root" | chpasswd
+
 RUN --security=insecure MACHINE=imx6ul-var-dart ./var_make_debian.sh -c rootfs
 
 ## TODO make the above steps into a separate stage or separate docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN --security=insecure MACHINE=imx6ul-var-dart ./var_make_debian.sh -c prep-roo
 RUN chroot /workdir/rootfs/ debconf-set-selections /debconf.set
 RUN chroot /workdir/rootfs/ rm -f /debconf.set
 RUN chroot /workdir/rootfs/ apt-get update || apt-get upgrade
-COPY variscite/protected_install /workdir/rootfs/usr/local/bin/protected_install
+COPY --chmod=755 variscite/protected_install /workdir/rootfs/usr/local/bin/protected_install
 RUN chroot /workdir/rootfs/ protected_install local-apt-repository
 RUN chroot /workdir/rootfs/ apt-get update || apt-get upgrade
 RUN chroot /workdir/rootfs/ protected_install udisks2

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,6 @@ RUN chroot /workdir/rootfs/ protected_install dh-python
 RUN chroot /workdir/rootfs/ protected_install apt-src
 RUN chroot /workdir/rootfs/ apt-get -y autoremove
 
-RUN --security=insecure MACHINE=imx6ul-var-dart ./var_make_debian.sh -c rootfs
-
 #update iptables alternatives to legacy
 RUN chroot /workdir/rootfs/ update-alternatives --set iptables /usr/sbin/iptables-legacy
 RUN chroot /workdir/rootfs/ update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/var_make_debian.sh
+++ b/var_make_debian.sh
@@ -1060,6 +1060,7 @@ function cmd_make_deploy()
 
 function cmd_make_prep_rootfs(){
 	make_prepare
+	cd ${G_ROOTFS_DIR}
 	make_debian_console_prepare_rootfs ${G_ROOTFS_DIR}
 }
 

--- a/var_make_debian.sh
+++ b/var_make_debian.sh
@@ -1058,10 +1058,13 @@ function cmd_make_deploy()
 	return 0
 }
 
+function cmd_make_prep-rootfs(){
+	make_prepare
+	make_debian_console_prepare_rootfs ${G_ROOTFS_DIR}
+}
+
 function cmd_make_rootfs()
 {
-	make_prepare;
-
 	if [ "${MACHINE}" = "imx6ul-var-dart" ] ||
 	   [ "${MACHINE}" = "var-som-mx7" ]; then
 		# make debian console rootfs
@@ -1207,6 +1210,9 @@ case $PARAM_CMD in
 	rootfs )
 		cmd_make_rootfs
 		;;
+	prep-rootfs )
+		cmd_make_prep_rootfs
+		;;
 	packrootfs )
 		cmd_make_pack_rootfs
 		;;
@@ -1247,6 +1253,7 @@ case $PARAM_CMD in
 		cmd_make_kmodules &&
 		cmd_make_kernel_header_deb &&
 		cmd_make_freertos_variscite &&
+		cmd_make_prepare_rootfs
 		cmd_make_rootfs
 		;;
 	clean )

--- a/var_make_debian.sh
+++ b/var_make_debian.sh
@@ -1058,7 +1058,7 @@ function cmd_make_deploy()
 	return 0
 }
 
-function cmd_make_prep-rootfs(){
+function cmd_make_prep_rootfs(){
 	make_prepare
 	make_debian_console_prepare_rootfs ${G_ROOTFS_DIR}
 }

--- a/variscite/console_rootfs.sh
+++ b/variscite/console_rootfs.sh
@@ -128,6 +128,7 @@ chmod +x ${ROOTFS_BASE}/usr/sbin/policy-rc.d
 
 function make_debian_console_rootfs()
 {
+	local ROOTFS_BASE=$1
 	# install variscite-bt service
 	install -d ${ROOTFS_BASE}/etc/bluetooth
 	if [ "${MACHINE}" = "imx6ul-var-dart" ] ||

--- a/variscite/console_rootfs.sh
+++ b/variscite/console_rootfs.sh
@@ -1,7 +1,7 @@
 # Must be called after make_prepare in main script
 # generate weston rootfs in input dir
 # $1 - rootfs base dir
-function make_debian_console_rootfs()
+function make_debian_console_prepare_rootfs()
 {
 	local ROOTFS_BASE=$1
 
@@ -124,172 +124,10 @@ exit 101
 EOF
 
 chmod +x ${ROOTFS_BASE}/usr/sbin/policy-rc.d
-
-# rootfs packages console only stage
-cat > rootfs-stage-console << EOF
-#!/bin/bash
-# apply debconfig options
-debconf-set-selections /debconf.set
-rm -f /debconf.set
-
-function protected_install()
-{
-	local _name=\${1}
-	local repeated_cnt=5;
-	local RET_CODE=1;
-
-	echo Installing \${_name}
-	for (( c=0; c<\${repeated_cnt}; c++ ))
-	do
-		apt install -y \${_name} && {
-			RET_CODE=0;
-			break;
-		};
-
-		echo
-		echo "##########################"
-		echo "## Fix missing packages ##"
-		echo "##########################"
-		echo
-
-		sleep 2;
-
-		apt --fix-broken install -y && {
-			RET_CODE=0;
-			break;
-		};
-	done
-
-	return \${RET_CODE}
 }
 
-# update packages and install base
-apt-get update || apt-get upgrade
-
-# local-apt-repository support
-protected_install local-apt-repository
-
-# update packages and install base
-apt-get update || apt-get upgrade
-
-#udisk2
-protected_install udisks2
-
-protected_install locales
-protected_install ntp
-protected_install openssh-server
-protected_install nfs-common
-
-# packages required when flashing emmc
-protected_install dosfstools
-
-# fix config for sshd (permit root login)
-sed -i -e 's/#PermitRootLogin.*/PermitRootLogin\tyes/g' /etc/ssh/sshd_config
-
-# net-tools (ifconfig, etc.)
-protected_install net-tools
-protected_install network-manager
-
-if [ "${MACHINE}" = "imx8mq-var-dart" ] ||
-   [ "${MACHINE}" = "imx8mm-var-dart" ] ||
-   [ "${MACHINE}" = "imx8mn-var-som" ] ||
-   [ "${MACHINE}" = "imx8mp-var-dart" ] ||
-   [ "${MACHINE}" = "imx8qm-var-som" ] ||
-   [ "${MACHINE}" = "imx8qxp-var-som" ] ||
-   [ "${MACHINE}" = "imx8qxpb0-var-som" ]; then
-	# sdma package
-	protected_install imx-firmware-sdma
-
-	# VPU package
-	protected_install imx-firmware-vpu
-
-	# epdc package
-	protected_install imx-firmware-epdc
-
-	# hdmi firmware package
-	if [ ! -z "${HDMI_FIRMWARE_PACKAGE}" ]
-	then
-		protected_install ${HDMI_FIRMWARE_PACKAGE}
-	fi
-fi
-
-# killall
-protected_install psmisc
-
-# alsa
-protected_install alsa-utils
-
-# i2c tools
-protected_install i2c-tools
-
-# usb tools
-protected_install usbutils
-
-# libgpiod
-protected_install gpiod
-protected_install libgpiod2
-protected_install python3-libgpiod
-
-# net tools
-protected_install iperf3
-
-protected_install rng-tools
-
-# mtd
-protected_install mtd-utils
-
-# bluetooth
-protected_install bluetooth
-protected_install bluez-obexd
-protected_install bluez-tools
-
-# install pulseaudio
-protected_install pulseaudio
-protected_install pulseaudio-module-bluetooth
-
-# wifi support packages
-protected_install hostapd
-protected_install udhcpd
-
-# disable the hostapd service by default
-systemctl disable hostapd.service
-
-# can support
-protected_install can-utils
-
-# pmount
-protected_install pmount
-
-# pm-utils
-protected_install pm-utils
-
-# install dpkg-dev for dpkg-buildpackage
-protected_install debhelper
-protected_install dh-python
-protected_install apt-src
-apt-get -y autoremove
-
-#update iptables alternatives to legacy
-update-alternatives --set iptables /usr/sbin/iptables-legacy
-update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-
-#install usleep busybox applet
-ln -sf /bin/busybox /bin/usleep
-
-# create users and set password
-useradd -m -G audio -s /bin/bash user
-usermod -a -G video user
-echo "user:user" | chpasswd
-echo "root:root" | chpasswd
-
-# sudo kill rootfs-stage-console
-rm -f rootfs-stage-console
-EOF
-
-	pr_info "rootfs: install selected Debian packages (console-only-stage)"
-	chmod +x rootfs-stage-console
-	chroot ${ROOTFS_BASE} /rootfs-stage-console
-
+function make_debian_console_rootfs()
+{
 	# install variscite-bt service
 	install -d ${ROOTFS_BASE}/etc/bluetooth
 	if [ "${MACHINE}" = "imx6ul-var-dart" ] ||

--- a/variscite/protected_install
+++ b/variscite/protected_install
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-_name=\${1}	
+_name=${1}	
 repeated_cnt=5;
 RET_CODE=1;
 
-echo Installing \${_name}
-for (( c=0; c<\${repeated_cnt}; c++ ))
+echo Installing ${_name}
+for (( c=0; c<${repeated_cnt}; c++ ))
 do
-	apt install -y \${_name} && {
+	apt install -y ${_name} && {
 		RET_CODE=0;
 		break;
 	};
@@ -25,4 +25,4 @@ do
 	};
 done
 
-exit \${RET_CODE}
+exit ${RET_CODE}

--- a/variscite/protected_install
+++ b/variscite/protected_install
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-local _name=\${1}	
-local repeated_cnt=5;
-local RET_CODE=1;
+_name=\${1}	
+repeated_cnt=5;
+RET_CODE=1;
 
 echo Installing \${_name}
 for (( c=0; c<\${repeated_cnt}; c++ ))

--- a/variscite/protected_install
+++ b/variscite/protected_install
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+local _name=\${1}	
+local repeated_cnt=5;
+local RET_CODE=1;
+
+echo Installing \${_name}
+for (( c=0; c<\${repeated_cnt}; c++ ))
+do
+	apt install -y \${_name} && {
+		RET_CODE=0;
+		break;
+	};
+	echo
+	echo "##########################"
+	echo "## Fix missing packages ##"
+	echo "##########################"
+	echo
+
+	sleep 2;
+
+	apt --fix-broken install -y && {
+		RET_CODE=0;
+		break;
+	};
+done
+
+exit \${RET_CODE}


### PR DESCRIPTION
This modifies the existing variscite bash scripts to install packages directly in the dockerfile. 

This enables layer caching of individual package installs, so if one fails due to ephemeral errors with debian servers, it can retry just that step and not the whole script command. 